### PR TITLE
Link back to main Alloy page

### DIFF
--- a/src/app/components/home-app/event-info/event-info.component.ts
+++ b/src/app/components/home-app/event-info/event-info.component.ts
@@ -167,7 +167,6 @@ export class EventInfoComponent implements OnInit, OnDestroy {
   }
 
   rejoinEvent() {
-    console.log('Opening ' + this.currentEvent.name + ' inside Player!!!');
     window.location.href =
       this.settingsService.settings.PlayerUIAddress +
       '/view/' +

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -9,26 +9,16 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 >
   <mat-toolbar-row>
     <span class="margin-auto">
-      <button
-        *ngIf="sidenav && sidenav?.opened"
-        (click)="sidenavToggleFn()"
-        color="primary"
-        mat-icon-button
-        matTooltip="Close Sidebar"
-      >
-        <mat-icon svgIcon="ic_chevron_left" [style.color]="topbarTextColor ? topbarTextColor : null"></mat-icon>
-      </button>
-      <button
-        *ngIf="sidenav && !sidenav?.opened"
-        (click)="sidenavToggleFn()"
-        color="primary"
-        mat-icon-button
-        matTooltip="Open Sidebar"
-      >
-        <mat-icon svgIcon="ic_chevron_right" [style.color]="topbarTextColor ? topbarTextColor : null"></mat-icon>
-      </button>
+      <a [routerLink]="['/']">
+        <div fxLayout="row" fxLayoutAlign="start center">
+          <mat-icon
+            class="alloy-icon"
+            svgIcon="ic_crucible_alloy"
+          ></mat-icon>        
+          <span class="view-text">{{ title }}</span>
+        </div>
+      </a>
     </span>
-    <span class="view-text">{{ title }}</span>
     <ng-container *ngIf="teams && team && teams.length > 0">
       <div class="team-text">Team:</div>
       <b class="team-text">{{ team.name }}</b>

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -9,12 +9,30 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 >
   <mat-toolbar-row>
     <span class="margin-auto">
+      <button
+        *ngIf="sidenav && sidenav?.opened"
+        (click)="sidenavToggleFn()"
+        color="primary"
+        mat-icon-button
+        matTooltip="Close Sidebar"
+      >
+        <mat-icon svgIcon="ic_chevron_left" [style.color]="topbarTextColor ? topbarTextColor : null"></mat-icon>
+      </button>
+      <button
+        *ngIf="sidenav && !sidenav?.opened"
+        (click)="sidenavToggleFn()"
+        color="primary"
+        mat-icon-button
+        matTooltip="Open Sidebar"
+      >
+        <mat-icon svgIcon="ic_chevron_right" [style.color]="topbarTextColor ? topbarTextColor : null"></mat-icon>
+      </button>
+    </span>
       <a [routerLink]="['/']">
         <div fxLayout="row" fxLayoutAlign="start center">       
           <span class="view-text">{{ title }}</span>
         </div>
       </a>
-    </span>
     <ng-container *ngIf="teams && team && teams.length > 0">
       <div class="team-text">Team:</div>
       <b class="team-text">{{ team.name }}</b>

--- a/src/app/components/shared/top-bar/topbar.component.html
+++ b/src/app/components/shared/top-bar/topbar.component.html
@@ -10,11 +10,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   <mat-toolbar-row>
     <span class="margin-auto">
       <a [routerLink]="['/']">
-        <div fxLayout="row" fxLayoutAlign="start center">
-          <mat-icon
-            class="alloy-icon"
-            svgIcon="ic_crucible_alloy"
-          ></mat-icon>        
+        <div fxLayout="row" fxLayoutAlign="start center">       
           <span class="view-text">{{ title }}</span>
         </div>
       </a>

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -20,7 +20,7 @@
   margin-right: 40px;
 }
 
-a, a:hover. a:focus {
+a, a:hover, a:focus {
   color: inherit;
   text-decoration: none;
 }

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -20,7 +20,7 @@
   margin-right: 40px;
 }
 
-a {
+a a:hover {
   color: inherit;
   text-decoration: none;
 }

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -20,7 +20,7 @@
   margin-right: 40px;
 }
 
-a, a:hover {
+a, a:hover. a:focus {
   color: inherit;
   text-decoration: none;
 }

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -19,3 +19,8 @@
   margin-left: 50px;
   margin-right: 40px;
 }
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -20,7 +20,7 @@
   margin-right: 40px;
 }
 
-a a:hover {
+a, a:hover {
   color: inherit;
   text-decoration: none;
 }


### PR DESCRIPTION
This PR creates matching functionality to other Crucible applications.  

When viewing an Alloy Event, the user can now click the "Alloy" text in the top bar to go back to the home page.

Addresses internal issue `CRU-1858`.