### PR TITLE
update to rxjs 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,10 +58,25 @@
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -406,6 +421,15 @@
             "glob": "^7.1.3"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "semver": {
           "version": "7.3.5",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -429,6 +453,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         },
         "type-fest": {
           "version": "0.21.3",
@@ -465,6 +495,23 @@
       "requires": {
         "@angular-devkit/architect": "0.1200.1",
         "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -580,6 +627,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "@angular-devkit/schematics": {
@@ -591,6 +649,17 @@
             "@angular-devkit/core": "12.0.1",
             "ora": "5.4.0",
             "rxjs": "6.6.7"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -741,6 +810,17 @@
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "json-schema-traverse": {
@@ -855,6 +935,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
           "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         },
         "type-fest": {
@@ -2831,6 +2917,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "@angular-devkit/schematics": {
@@ -2842,6 +2939,17 @@
             "@angular-devkit/core": "12.0.1",
             "ora": "5.4.0",
             "rxjs": "6.6.7"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -2989,6 +3097,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -4504,6 +4618,15 @@
           "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4705,6 +4828,14 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4712,6 +4843,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -9340,6 +9476,16 @@
             "string-width": "^2.1.0",
             "strip-ansi": "^5.1.0",
             "through": "^2.3.6"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "is-fullwidth-code-point": {
@@ -9380,6 +9526,11 @@
               "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             }
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -12837,17 +12988,17 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.1.0.tgz",
+      "integrity": "sha512-gCFO5iHIbRPwznl6hAYuwNFld8W4S2shtSJIqG27ReWXo9IWrCyEICxUA+6vJHwSR/OakoenC4QsDxq50tzYmw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -13089,6 +13240,19 @@
         "typescript": "^3.3.3333"
       },
       "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
         "typescript": {
           "version": "3.9.9",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "core-js": "^3.12.1",
     "@microsoft/signalr": "^5.0.6",
     "oidc-client": "^1.11.5",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.1.0",
     "rxjs-compat": "^6.6.7",
     "tslib": "^2.2.0",
     "zone.js": "~0.11.4"

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
@@ -406,7 +406,7 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
   }
 } // End Class

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
@@ -62,7 +62,7 @@ export class EventTemplateListComponent implements OnDestroy {
   }
 
   ngOnDestroy() {
-    this.unsubscribe$.next();
+    this.unsubscribe$.next(null);
     this.unsubscribe$.complete();
   }
 

--- a/src/app/components/home-app/enlist/enlist.component.scss
+++ b/src/app/components/home-app/enlist/enlist.component.scss
@@ -2,4 +2,3 @@
 Copyright 2021 Carnegie Mellon University. All Rights Reserved. 
  Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 */
-

--- a/src/app/components/home-app/enlist/enlist.component.spec.ts
+++ b/src/app/components/home-app/enlist/enlist.component.spec.ts
@@ -13,9 +13,8 @@ describe('EnlistComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ EnlistComponent ]
-    })
-    .compileComponents();
+      declarations: [EnlistComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/src/app/components/home-app/event-list/event-list.component.ts
+++ b/src/app/components/home-app/event-list/event-list.component.ts
@@ -14,8 +14,8 @@ import { Router } from '@angular/router';
 import { ComnAuthQuery, Theme } from '@cmusei/crucible-common';
 import { combineQueries } from '@datorama/akita';
 import { RouterQuery } from '@datorama/akita-ng-router-store';
-import { Observable, Subject } from 'rxjs';
-import { filter, shareReplay, takeUntil, tap } from 'rxjs/operators';
+import { Observable, Subject, ReplaySubject } from 'rxjs';
+import { filter, share, takeUntil, tap } from 'rxjs/operators';
 import { EventTemplate } from 'src/app/generated/alloy.api/model/eventTemplate';
 import { EventTemplatesService } from 'src/app/services/event-templates/event-templates.service';
 import { EventsService } from '../../../services/events/events.service';
@@ -97,7 +97,11 @@ export class EventListComponent implements OnInit, OnDestroy {
       )
       .subscribe();
 
-    this.isLoading$ = this.TemplatesQuery.selectLoading().pipe(shareReplay());
+    this.isLoading$ = this.TemplatesQuery.selectLoading().pipe(
+      share({
+        connector: () => new ReplaySubject(),
+      })
+    );
   }
 
   /**

--- a/src/app/components/home-app/event-template-info/event-template-info.component.ts
+++ b/src/app/components/home-app/event-template-info/event-template-info.component.ts
@@ -10,11 +10,11 @@ import {
 } from '@cmusei/crucible-common';
 import { RouterQuery } from '@datorama/akita-ng-router-store';
 import { ClipboardService } from 'ngx-clipboard';
-import { Observable, of, Subject } from 'rxjs';
+import { Observable, of, Subject, ReplaySubject } from 'rxjs';
 import {
   filter,
   map,
-  shareReplay,
+  share,
   switchMap,
   take,
   takeUntil,
@@ -125,7 +125,9 @@ export class EventTemplateInfoComponent implements OnInit, OnDestroy {
       switchMap((id) => {
         return this.templatesQuery.selectEntity(id ? id : this.eventTemplateId);
       }),
-      shareReplay(),
+      share({
+        connector: () => new ReplaySubject(),
+      }),
       takeUntil(this.unsubscribe$)
     );
 
@@ -136,7 +138,9 @@ export class EventTemplateInfoComponent implements OnInit, OnDestroy {
           .pipe(map((events) => events));
       }),
       tap((events) => (this.impsDataSource.data = events)),
-      shareReplay(),
+      share({
+        connector: () => new ReplaySubject(),
+      }),
       takeUntil(this.unsubscribe$)
     );
 
@@ -156,7 +160,9 @@ export class EventTemplateInfoComponent implements OnInit, OnDestroy {
           return ownerEvent;
         }
       }),
-      shareReplay(),
+      share({
+        connector: () => new ReplaySubject(),
+      }),
       takeUntil(this.unsubscribe$)
     );
 
@@ -169,7 +175,9 @@ export class EventTemplateInfoComponent implements OnInit, OnDestroy {
         );
       }),
       filter((events) => events.length >= 1),
-      shareReplay(),
+      share({
+        connector: () => new ReplaySubject(),
+      }),
       takeUntil(this.unsubscribe$)
     );
   }

--- a/src/app/services/event-templates/event-templates.service.ts
+++ b/src/app/services/event-templates/event-templates.service.ts
@@ -3,15 +3,14 @@
 
 import { Injectable } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
 import {
-  map,
-  shareReplay,
-  switchMap,
-  take,
-  takeUntil,
-  tap,
-} from 'rxjs/operators';
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  Subject,
+  ReplaySubject,
+} from 'rxjs';
+import { map, share, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import {
   EventTemplate,
   EventTemplateService,
@@ -69,7 +68,9 @@ export class EventTemplatesService {
           );
         }
       }),
-      shareReplay(1)
+      share({
+        connector: () => new ReplaySubject(1),
+      })
     );
     this.currentEventTemplate$ = this.currentEventTemplateId$.pipe(
       switchMap((id) => {


### PR DESCRIPTION
Update to `rxjs 7`.

- `next()` now requests a parameter, since it's not being used in our application, we are passing in `null`.
- Upgrades `shareReplay` to `share` using [this guide -- search for shareReplay](https://medium.com/volosoft/whats-new-in-rxjs-7-a11cc564c6c0).

Solves internal ticket `CRU-1881`.