### PR TITLE
Persist auth theme to localStorage to fix dark mode lost on refresh

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,18 @@
 
 import { enableProdMode, provideZoneChangeDetection } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { enableAkitaProdMode, persistState } from '@datorama/akita';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+export const storage = persistState({
+  key: 'akita-alloy-ui',
+  include: ['auth.ui'],
+});
+
 if (environment.production) {
   enableProdMode();
+  enableAkitaProdMode();
 }
 
 platformBrowserDynamic()


### PR DESCRIPTION
Persist dark mode theme across page refreshes                                                                                                                           

Add Akita persistState to save the auth store's theme selection to localStorage. Previously, toggling dark mode via the menu would revert to light mode on page refresh since the theme was only held in memory. This uses the same pattern as Player UI.