### PR TITLE
Clean up dialog styling and standardize button text color

### DIFF
--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
@@ -15,156 +15,127 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     </button>
   </div>
   @if (data.eventTemplate) {
-  <mat-dialog-content mat-dialog-content>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Name (required)</mat-label>
-          <input type="text" matInput [(ngModel)]="data.eventTemplate.name"
-            [disabled]="!data.canEdit" />
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Event Template Description</mat-label>
-          <textarea matInput [(ngModel)]="data.eventTemplate.description"
-            [disabled]="!data.canEdit"></textarea>
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Duration Hours</mat-label>
-          <input matInput type="number" [(ngModel)]="data.eventTemplate.durationHours"
-            [disabled]="!data.canEdit" />
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Player View Template</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="viewSearchControl" [matAutocomplete]="autoView" />
-          <mat-autocomplete #autoView="matAutocomplete" ngDefaultControl [displayWith]="selectedViewName"
-            [(ngModel)]="data.eventTemplate.viewId"
-            (optionSelected)="saveEventIds($event, 'viewId')" (opened)="filterViews()">
-            <mat-option [value]="null">None</mat-option>
-            @for (view of filteredViewList | async; track view) {
-            <mat-option [value]="view.id">
-              {{ view.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="viewSearchControl.value"
-            [disabled]="true" />
-          }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.viewId"
-            title="Copy:  {{ data.eventTemplate.viewId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Caster Directory</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="directorySearchControl" [matAutocomplete]="autoDirectory" />
-          <mat-autocomplete #autoDirectory="matAutocomplete" ngDefaultControl [displayWith]="selectedDirectoryName"
-            [(ngModel)]="data.eventTemplate.directoryId"
-            (optionSelected)="saveEventIds($event, 'directoryId')" (opened)="filterDirectories()">
-            <mat-option [value]="null">None</mat-option>
-            @for (directory of filteredDirectoryList | async; track directory) {
-            <mat-option [value]="directory.id">
-              {{ directory.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="directorySearchControl.value"
-            [disabled]="true" />
-          }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.directoryId"
-            title="Copy:  {{ data.eventTemplate.directoryId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div>
-        <mat-form-field class="full-width">
-          <mat-label>Steamfitter Scenario Template</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="scenarioTemplateSearchControl"
-            [matAutocomplete]="autoScenarioTemplate" />
-          <mat-autocomplete #autoScenarioTemplate="matAutocomplete" ngDefaultControl
-            [displayWith]="selectedEventTemplateName"
-            [(ngModel)]="data.eventTemplate.scenarioTemplateId"
-            (optionSelected)="saveEventIds($event, 'scenarioTemplateId')" (opened)="filterScenarioTemplates()"
-            (closed)="scenarioTemplateSearchControl.setValue('')">
-            <mat-option [value]="null">None</mat-option>
-            @for (
-            scenarioTemplate of filteredScenarioTemplateList | async
-            ; track
-            scenarioTemplate) {
-            <mat-option [value]="scenarioTemplate.id">
-              {{ scenarioTemplate.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="scenarioTemplateSearchControl.value"
-            [disabled]="true" />
-          }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
-            title="Copy:  {{ data.eventTemplate.scenarioTemplateId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
-        </mat-form-field>
-      </div>
-    </div>
-    <div class="add-margin">
-      <mat-checkbox [(ngModel)]="data.eventTemplate.isPublished"
-        title="Makes this template available to ALL authenticated users"
-        [disabled]="!data.canEdit">Public</mat-checkbox>
-    </div>
-    <div class="add-margin">
-      <mat-checkbox [(ngModel)]="data.eventTemplate.useDynamicHost"
-        title="Dynamically assigns host addresses for deployed infrastructure"
-        [disabled]="!data.canEdit">Use Dynamic
-        Host</mat-checkbox>
-    </div>
+  <mat-dialog-content>
+    <mat-form-field class="full-width">
+      <mat-label>Name (required)</mat-label>
+      <input type="text" matInput [(ngModel)]="data.eventTemplate.name"
+        [disabled]="!data.canEdit" />
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Event Template Description</mat-label>
+      <textarea matInput [(ngModel)]="data.eventTemplate.description"
+        [disabled]="!data.canEdit"></textarea>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Duration Hours</mat-label>
+      <input matInput type="number" [(ngModel)]="data.eventTemplate.durationHours"
+        [disabled]="!data.canEdit" />
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Player View Template</mat-label>
+      @if (data.canEdit) {
+      <input matInput type="text" [formControl]="viewSearchControl" [matAutocomplete]="autoView" />
+      <mat-autocomplete #autoView="matAutocomplete" ngDefaultControl [displayWith]="selectedViewName"
+        [(ngModel)]="data.eventTemplate.viewId"
+        (optionSelected)="saveEventIds($event, 'viewId')" (opened)="filterViews()">
+        <mat-option [value]="null">None</mat-option>
+        @for (view of filteredViewList | async; track view) {
+        <mat-option [value]="view.id">
+          {{ view.name }}
+        </mat-option>
+        }
+      </mat-autocomplete>
+      } @else {
+      <input matInput type="text" [value]="viewSearchControl.value"
+        [disabled]="true" />
+      }
+      <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.viewId"
+        title="Copy:  {{ data.eventTemplate.viewId }}">
+        <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Caster Directory</mat-label>
+      @if (data.canEdit) {
+      <input matInput type="text" [formControl]="directorySearchControl" [matAutocomplete]="autoDirectory" />
+      <mat-autocomplete #autoDirectory="matAutocomplete" ngDefaultControl [displayWith]="selectedDirectoryName"
+        [(ngModel)]="data.eventTemplate.directoryId"
+        (optionSelected)="saveEventIds($event, 'directoryId')" (opened)="filterDirectories()">
+        <mat-option [value]="null">None</mat-option>
+        @for (directory of filteredDirectoryList | async; track directory) {
+        <mat-option [value]="directory.id">
+          {{ directory.name }}
+        </mat-option>
+        }
+      </mat-autocomplete>
+      } @else {
+      <input matInput type="text" [value]="directorySearchControl.value"
+        [disabled]="true" />
+      }
+      <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.directoryId"
+        title="Copy:  {{ data.eventTemplate.directoryId }}">
+        <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-form-field class="full-width">
+      <mat-label>Steamfitter Scenario Template</mat-label>
+      @if (data.canEdit) {
+      <input matInput type="text" [formControl]="scenarioTemplateSearchControl"
+        [matAutocomplete]="autoScenarioTemplate" />
+      <mat-autocomplete #autoScenarioTemplate="matAutocomplete" ngDefaultControl
+        [displayWith]="selectedEventTemplateName"
+        [(ngModel)]="data.eventTemplate.scenarioTemplateId"
+        (optionSelected)="saveEventIds($event, 'scenarioTemplateId')" (opened)="filterScenarioTemplates()"
+        (closed)="scenarioTemplateSearchControl.setValue('')">
+        <mat-option [value]="null">None</mat-option>
+        @for (
+        scenarioTemplate of filteredScenarioTemplateList | async
+        ; track
+        scenarioTemplate) {
+        <mat-option [value]="scenarioTemplate.id">
+          {{ scenarioTemplate.name }}
+        </mat-option>
+        }
+      </mat-autocomplete>
+      } @else {
+      <input matInput type="text" [value]="scenarioTemplateSearchControl.value"
+        [disabled]="true" />
+      }
+      <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
+        title="Copy:  {{ data.eventTemplate.scenarioTemplateId }}">
+        <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
+      </button>
+    </mat-form-field>
+
+    <mat-checkbox [(ngModel)]="data.eventTemplate.isPublished"
+      title="Makes this template available to ALL authenticated users"
+      [disabled]="!data.canEdit">Public</mat-checkbox>
+
+    <mat-checkbox [(ngModel)]="data.eventTemplate.useDynamicHost"
+      title="Dynamically assigns host addresses for deployed infrastructure"
+      [disabled]="!data.canEdit">Use Dynamic Host</mat-checkbox>
   </mat-dialog-content>
   }
 
-  <div class="cssLayoutRowStartCenter bottom-button">
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template"
-        [disabled]="!data.canEdit">Save</button>
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="cloneEventTemplate()" class="clone-button" title="Clone this event template"
-        style="margin-left: 80px;" [disabled]="!data.canCreate">
-        Clone
-      </button>
-    </div>
-    <div class="delete-button"
-      [matTooltip]="data.hasEvents ? 'Cannot delete template with existing events' : 'Delete this event template'"
-      style="display: inline-block;">
+  <mat-dialog-actions>
+    <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template"
+      [disabled]="!data.canEdit">Save</button>
+    <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
+    <button mat-stroked-button (click)="cloneEventTemplate()" title="Clone this event template"
+      [disabled]="!data.canCreate">
+      Clone
+    </button>
+    <div
+      [matTooltip]="data.hasEvents ? 'Cannot delete template with existing events' : 'Delete this event template'">
       <button mat-stroked-button (click)="deleteEventTemplate()"
-        style="margin-left: 80px;" [disabled]="!data.canManage || data.hasEvents">
+        [disabled]="!data.canManage || data.hasEvents">
         Delete
       </button>
     </div>
-  </div>
+  </mat-dialog-actions>
 </div>

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
@@ -1,19 +1,25 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-.add-margin {
-  margin-top: 8px;
-  margin-bottom: 8px;
+mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 8px;
+  scrollbar-color: var(--mat-sys-outline) transparent;
+  scrollbar-width: thin;
 }
 
-.bottom-button {
-  margin-bottom: 10px;
-  margin-top: 10px;
+mat-dialog-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 0;
 }
 
-.delete-button {
-  margin-top: 10px;
-  margin-right: 50px;
+
+.close-button {
+  float: right;
 }
 
 ::ng-deep .mat-autocomplete-panel {
@@ -22,10 +28,18 @@
   border-width: 1px;
 }
 
-.clone-button {
-  margin-left: 40px;
+::ng-deep .mdc-text-field {
+  overflow: visible;
 }
 
-.close-button {
-  float: right;
+::ng-deep .mat-mdc-form-field-icon-suffix {
+  overflow: visible;
+}
+
+::ng-deep .mat-mdc-form-field-icon-suffix .mat-mdc-icon-button {
+  overflow: visible;
+}
+
+::ng-deep .mat-mdc-form-field-icon-suffix .mat-mdc-icon-button .mat-icon {
+  overflow: visible;
 }

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
@@ -170,9 +170,8 @@ export class EventTemplateListComponent implements AfterViewInit, OnDestroy, OnI
         const hasEvents = events && events.length > 0;
 
         const dialogRef = this.dialog.open(EventTemplateEditComponent, {
-          minWidth: '400px',
+          width: '750px',
           maxWidth: '90vw',
-          width: 'auto',
           data: {
             eventTemplate: { ...eventTemplate },
             viewList: this.viewList,

--- a/src/app/components/admin-app/events/event-edit/event-edit.component.html
+++ b/src/app/components/admin-app/events/event-edit/event-edit.component.html
@@ -11,226 +11,172 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
     </button>
   </div>
   @if (data.event) {
-    <mat-dialog-content mat-dialog-content>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Name (required)</mat-label>
-            <input type="text" matInput [formControl]="eventNameFormControl" placeholder="Name (required)"
-              (blur)="saveEvent('name')" value="{{ data.event.name }}" [errorStateMatcher]="matcher" />
-            @if (
-              eventNameFormControl.hasError('minlength') &&
-              !eventNameFormControl.hasError('required')
-              ) {
-              <mat-error>
-                Must contain 4 or more characters
-              </mat-error>
-            }
-            @if (eventNameFormControl.hasError('required')) {
-              <mat-error>
-                Name is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Description</mat-label>
-            <textarea matInput placeholder="Description" [formControl]="descriptionFormControl"
-              (blur)="saveEvent('description')" value="{{ data.event.description }}"
-            [errorStateMatcher]="matcher"></textarea>
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Username</mat-label>
-            <input matInput placeholder="Username" [formControl]="usernameFormControl" (blur)="saveEvent('username')"
-              value="{{ data.event.username }}" [errorStateMatcher]="matcher" />
-            @if (usernameFormControl.hasError('required')) {
-              <mat-error>
-                Username is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Status</mat-label>
-            <input matInput placeholder="Status" [formControl]="statusFormControl" (blur)="saveEvent('status')"
-              value="{{ data.event.status }}" [errorStateMatcher]="matcher" />
-            @if (statusFormControl.hasError('required')) {
-              <mat-error>
-                Status is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Internal Status</mat-label>
-            <input matInput placeholder="Internal Status" [formControl]="internalStatusFormControl"
-              (blur)="saveEvent('internalStatus')" value="{{ data.event.internalStatus }}"
-              [errorStateMatcher]="matcher" />
-            @if (internalStatusFormControl.hasError('required')) {
-              <mat-error>
-                Internal Status is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>User ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.userId"
-              title="Copy:  {{ data.event.userId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="User ID" [formControl]="userIdFormControl" (blur)="saveEvent('userId')"
-              value="{{ data.event.userId }}" [errorStateMatcher]="matcher" />
-            @if (userIdFormControl.hasError('required')) {
-              <mat-error>
-                User ID is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Event Template ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.eventTemplateId"
-              title="Copy:  {{ data.event.eventTemplateId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="Event Template ID" [formControl]="eventTemplateIdFormControl"
-              (blur)="saveEvent('eventTemplateId')" value="{{ data.event.eventTemplateId }}"
-              [errorStateMatcher]="matcher" />
-            @if (eventTemplateIdFormControl.hasError('required')) {
-              <mat-error>
-                Event Template ID is <strong>required</strong>
-              </mat-error>
-            }
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>View ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.viewId"
-              title="Copy:  {{ data.event.viewId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="View ID" [formControl]="viewIdFormControl" (blur)="saveEvent('viewId')"
-              value="{{ data.event.viewId }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Workspace ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.workspaceId"
-              title="Copy:  {{ data.event.workspaceId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="Workspace ID" [formControl]="workspaceIdFormControl"
-              (blur)="saveEvent('workspaceId')" value="{{ data.event.workspaceId }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Run ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.runId"
-              title="Copy:  {{ data.event.runId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="Run ID" [formControl]="runIdFormControl" (blur)="saveEvent('runId')"
-              value="{{ data.event.runId }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Scenario ID</mat-label>
-            <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.scenarioId"
-              title="Copy:  {{ data.event.scenarioId }}" style="margin-top: -15px">
-              <mat-icon style="transform: scale(0.65)" svgIcon="ic_clipboard_copy"></mat-icon>
-            </button>
-            <input matInput placeholder="Scenario ID" [formControl]="scenarioIdFormControl" (blur)="saveEvent('eventId')"
-              value="{{ data.event.scenarioId }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Launch Date</mat-label>
-            <input matInput placeholder="Launch Date" [formControl]="launchDateFormControl"
-              (blur)="saveEvent('launchDate')" value="{{ data.event.launchDate }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>End Date</mat-label>
-            <input matInput placeholder="End Date" [formControl]="endDateFormControl" (blur)="saveEvent('endDate')"
-              value="{{ data.event.endDate }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Expiration Date</mat-label>
-            <input matInput placeholder="Expiration Date" [formControl]="expirationDateFormControl"
-              (blur)="saveEvent('expirationDate')" value="{{ data.event.expirationDate }}"
-              [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
-      <div class="add-margin">
-        <div>
-          <mat-form-field class="full-width">
-            <mat-label>Status Date</mat-label>
-            <input matInput placeholder="Status Date" [formControl]="statusDateFormControl"
-              (blur)="saveEvent('statusDate')" value="{{ data.event.statusDate }}" [errorStateMatcher]="matcher" />
-          </mat-form-field>
-        </div>
-      </div>
+    <mat-dialog-content>
+      <mat-form-field class="full-width">
+        <mat-label>Name (required)</mat-label>
+        <input type="text" matInput [formControl]="eventNameFormControl" placeholder="Name (required)"
+          (blur)="saveEvent('name')" value="{{ data.event.name }}" [errorStateMatcher]="matcher" />
+        @if (
+          eventNameFormControl.hasError('minlength') &&
+          !eventNameFormControl.hasError('required')
+          ) {
+          <mat-error>
+            Must contain 4 or more characters
+          </mat-error>
+        }
+        @if (eventNameFormControl.hasError('required')) {
+          <mat-error>
+            Name is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Description</mat-label>
+        <textarea matInput placeholder="Description" [formControl]="descriptionFormControl"
+          (blur)="saveEvent('description')" value="{{ data.event.description }}"
+          [errorStateMatcher]="matcher"></textarea>
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Username</mat-label>
+        <input matInput placeholder="Username" [formControl]="usernameFormControl" (blur)="saveEvent('username')"
+          value="{{ data.event.username }}" [errorStateMatcher]="matcher" />
+        @if (usernameFormControl.hasError('required')) {
+          <mat-error>
+            Username is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Status</mat-label>
+        <input matInput placeholder="Status" [formControl]="statusFormControl" (blur)="saveEvent('status')"
+          value="{{ data.event.status }}" [errorStateMatcher]="matcher" />
+        @if (statusFormControl.hasError('required')) {
+          <mat-error>
+            Status is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Internal Status</mat-label>
+        <input matInput placeholder="Internal Status" [formControl]="internalStatusFormControl"
+          (blur)="saveEvent('internalStatus')" value="{{ data.event.internalStatus }}"
+          [errorStateMatcher]="matcher" />
+        @if (internalStatusFormControl.hasError('required')) {
+          <mat-error>
+            Internal Status is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>User ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.userId"
+          title="Copy:  {{ data.event.userId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="User ID" [formControl]="userIdFormControl" (blur)="saveEvent('userId')"
+          value="{{ data.event.userId }}" [errorStateMatcher]="matcher" />
+        @if (userIdFormControl.hasError('required')) {
+          <mat-error>
+            User ID is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Event Template ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.eventTemplateId"
+          title="Copy:  {{ data.event.eventTemplateId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="Event Template ID" [formControl]="eventTemplateIdFormControl"
+          (blur)="saveEvent('eventTemplateId')" value="{{ data.event.eventTemplateId }}"
+          [errorStateMatcher]="matcher" />
+        @if (eventTemplateIdFormControl.hasError('required')) {
+          <mat-error>
+            Event Template ID is <strong>required</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>View ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.viewId"
+          title="Copy:  {{ data.event.viewId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="View ID" [formControl]="viewIdFormControl" (blur)="saveEvent('viewId')"
+          value="{{ data.event.viewId }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Workspace ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.workspaceId"
+          title="Copy:  {{ data.event.workspaceId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="Workspace ID" [formControl]="workspaceIdFormControl"
+          (blur)="saveEvent('workspaceId')" value="{{ data.event.workspaceId }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Run ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.runId"
+          title="Copy:  {{ data.event.runId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="Run ID" [formControl]="runIdFormControl" (blur)="saveEvent('runId')"
+          value="{{ data.event.runId }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Scenario ID</mat-label>
+        <button mat-icon-button matPrefix ngxClipboard [cbContent]="data.event.scenarioId"
+          title="Copy:  {{ data.event.scenarioId }}" class="clipboard-button">
+          <mat-icon class="clipboard-icon" svgIcon="ic_clipboard_copy"></mat-icon>
+        </button>
+        <input matInput placeholder="Scenario ID" [formControl]="scenarioIdFormControl" (blur)="saveEvent('eventId')"
+          value="{{ data.event.scenarioId }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Launch Date</mat-label>
+        <input matInput placeholder="Launch Date" [formControl]="launchDateFormControl"
+          (blur)="saveEvent('launchDate')" value="{{ data.event.launchDate }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>End Date</mat-label>
+        <input matInput placeholder="End Date" [formControl]="endDateFormControl" (blur)="saveEvent('endDate')"
+          value="{{ data.event.endDate }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Expiration Date</mat-label>
+        <input matInput placeholder="Expiration Date" [formControl]="expirationDateFormControl"
+          (blur)="saveEvent('expirationDate')" value="{{ data.event.expirationDate }}"
+          [errorStateMatcher]="matcher" />
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+        <mat-label>Status Date</mat-label>
+        <input matInput placeholder="Status Date" [formControl]="statusDateFormControl"
+          (blur)="saveEvent('statusDate')" value="{{ data.event.statusDate }}" [errorStateMatcher]="matcher" />
+      </mat-form-field>
     </mat-dialog-content>
   }
-  <div class="bottom-button cssLayoutRowCenterCenter">
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template" [disabled]="!data.canEdit">Save</button>
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
-    </div>
-    <div class="delete-button">
-      @if (data.event.status !== 'Ended') {
-        <button mat-stroked-button (click)="endEvent()" style="margin-left: 80px" [disabled]="!data.canManage">
-          End Event Now
-        </button>
-      }
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="deleteEvent()" style="margin-left: 80px" [disabled]="!data.canManage">Delete Event</button>
-    </div>
-  </div>
+  <mat-dialog-actions>
+    <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template" [disabled]="!data.canEdit">Save</button>
+    <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
+    @if (data.event.status !== 'Ended') {
+      <button mat-stroked-button (click)="endEvent()" [disabled]="!data.canManage">
+        End Event Now
+      </button>
+    }
+    <button mat-stroked-button (click)="deleteEvent()" [disabled]="!data.canManage">Delete Event</button>
+  </mat-dialog-actions>
 </div>

--- a/src/app/components/admin-app/events/event-edit/event-edit.component.scss
+++ b/src/app/components/admin-app/events/event-edit/event-edit.component.scss
@@ -1,31 +1,36 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-.add-margin {
-  margin-top: 8px;
-  margin-bottom: 8px;
+mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 8px;
+  scrollbar-color: var(--mat-sys-outline) transparent;
+  scrollbar-width: thin;
 }
 
-.bottom-button {
-  margin-bottom: 10px;
-  margin-top: 10px;
+mat-dialog-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 0;
 }
 
-.delete-button {
-  margin-top: 10px;
-  margin-right: 50px;
+.clipboard-button {
+  margin-top: -15px;
+}
+
+.clipboard-icon {
+  transform: scale(0.65);
+}
+
+.close-button {
+  float: right;
 }
 
 ::ng-deep .mat-autocomplete-panel {
   border-style: solid;
   border-color: var(--mat-sys-outline);
   border-width: 1px;
-}
-
-.clone-button {
-  margin-left: 40px;
-}
-
-.close-button {
-  float: right;
 }

--- a/src/app/components/admin-app/events/event-list/event-list.component.ts
+++ b/src/app/components/admin-app/events/event-list/event-list.component.ts
@@ -234,9 +234,8 @@ export class AdminEventListComponent implements OnInit {
 
   editEvent(event: AlloyEvent) {
     const dialogRef = this.dialog.open(EventEditComponent, {
-      minWidth: '400px',
+      width: '750px',
       maxWidth: '90vw',
-      width: 'auto',
       data: {
         event: { ...event },
         canEdit: this.canEdit(event.id),

--- a/src/app/components/shared/confirm-dialog/components/confirm-dialog.component.html
+++ b/src/app/components/shared/confirm-dialog/components/confirm-dialog.component.html
@@ -4,21 +4,21 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 
 <h1 mat-dialog-title>{{ title }}</h1>
-<div class="message-text">{{ message }}</div>
+<mat-dialog-content>
+  <p class="message-text">{{ message }}</p>
+</mat-dialog-content>
 
-<mat-dialog-actions fxLayout="row" fxLayoutAlign="space-around center">
-  <div>
-    @if (buttonTrueText !== '') {
-      <button
-        mat-stroked-button
-        hotkeyAction="ENTER"
-        (click)="onClick(true)"
-        tabindex="3"
-        >
-        {{ buttonTrueText }}
-      </button>
-    }
-  </div>
+<mat-dialog-actions>
+  @if (buttonTrueText !== '') {
+    <button
+      mat-stroked-button
+      hotkeyAction="ENTER"
+      (click)="onClick(true)"
+      tabindex="3"
+      >
+      {{ buttonTrueText }}
+    </button>
+  }
   <button mat-stroked-button (click)="onCancel()" tabindex="3">
     {{ buttonFalseText }}
   </button>

--- a/src/app/components/shared/confirm-dialog/components/confirm-dialog.component.scss
+++ b/src/app/components/shared/confirm-dialog/components/confirm-dialog.component.scss
@@ -1,8 +1,25 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
+h1 {
+  text-align: center;
+}
+
+mat-dialog-content {
+  padding-top: 8px;
+}
+
 .message-text {
-  font-size: medium;
-  margin-bottom: 20px;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+  text-align: center;
   color: var(--mat-sys-on-surface);
+}
+
+mat-dialog-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 24px 16px;
 }

--- a/src/app/components/shared/top-bar/topbar.component.scss
+++ b/src/app/components/shared/top-bar/topbar.component.scss
@@ -37,6 +37,11 @@
   color: var(--mat-sys-on-primary);
 }
 
+// header bar text stays white on the colored bar, overriding the global default
+::ng-deep .menu-trigger .mdc-button__label {
+  color: var(--mat-sys-on-primary) !important;
+}
+
 a,
 a:hover,
 a:focus {

--- a/src/app/shared/name-dialog/name-dialog.component.html
+++ b/src/app/shared/name-dialog/name-dialog.component.html
@@ -4,7 +4,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 
 <h1 mat-dialog-title>{{ title }}</h1>
-<div style="font-family: 'open_sansregular', sans-serif">{{ message }}</div>
+<div class="message-text">{{ message }}</div>
 
 <form [formGroup]="form" class="name-form">
   <mat-form-field class="form-full-width">
@@ -28,7 +28,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </mat-form-field>
 </form>
 
-<mat-dialog-actions fxLayout="row" fxLayoutAlign="space-around center">
+<mat-dialog-actions>
   <button
     mat-stroked-button
     hotkeyAction="ENTER"

--- a/src/app/shared/name-dialog/name-dialog.component.scss
+++ b/src/app/shared/name-dialog/name-dialog.component.scss
@@ -3,6 +3,11 @@ Copyright 2025 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 */
 
+.message-text {
+  font-size: medium;
+  color: var(--mat-sys-on-surface);
+}
+
 .name-form {
   min-width: 150px;
   max-width: 500px;
@@ -11,4 +16,11 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
 .form-full-width {
   width: 100%;
+}
+
+mat-dialog-actions {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 0;
 }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -134,6 +134,11 @@ mat-icon,
   --mat-icon-color: var(--mat-sys-primary);
 }
 
+// button text follows the theme (black in light, white in dark)
+.mat-mdc-button-base .mdc-button__label {
+  color: var(--mat-sys-on-surface) !important;
+}
+
 // remove the border around paginator items per page selection
 mat-paginator {
   --mat-form-field-outlined-outline-color: transparent;


### PR DESCRIPTION
Dialogs updated

- Event Edit — removed redundant wrapper divs, flexbox spacing, extracted inline styles, theme-aware scrollbar, widened to 750px
- Event Template Edit — same cleanup, widened to 750px, fixed clipboard icon being clipped in the form-field suffix
- Confirm Dialog — wrapped message in mat-dialog-content for proper padding, centered title/message/buttons, removed deprecated fxLayout attributes
- Name Dialog — removed deprecated fxLayout attributes, extracted inline styles, centered actions

Changes
- Replaced custom footer divs with mat-dialog-actions and consistent flexbox gaps
- Removed inline style="..." attributes in favor of CSS classes
- Added theme-aware scrollbars (scrollbar-color via Material system tokens) to scrollable dialogs
- Added a global theme-adaptive button text color (--mat-sys-on-surface → black in light theme, white in dark)
- Top bar user button overrides to stay white (--mat-sys-on-primary) on the colored header