### PR TITLE
Feature/add template dialog and standardize admin pages

### DIFF
--- a/src/app/components/admin-app/admin-users/admin-users.component.html
+++ b/src/app/components/admin-app/admin-users/admin-users.component.html
@@ -4,12 +4,8 @@ Released under a MIT (SEI)-style license, please see LICENSE.md in the
 project root for license information or contact permission@sei.cmu.edu for full terms.
 -->
 
-<div class="component-container mat-elevation-z8">
-  <div class="add-margin">
-    @if (!!users$ && !!isLoading$) {
-      <app-admin-user-list [users]="users$ | async" [isLoading]="isLoading$ | async"
-        [canEdit]="canEdit" (create)="create($event)" (delete)="deleteUser($event)">
-      </app-admin-user-list>
-    }
-  </div>
-</div>
+@if (!!users$ && !!isLoading$) {
+  <app-admin-user-list [users]="users$ | async" [isLoading]="isLoading$ | async"
+    [canEdit]="canEdit" (create)="create($event)" (delete)="deleteUser($event)">
+  </app-admin-user-list>
+}

--- a/src/app/components/admin-app/admin-users/admin-users.component.scss
+++ b/src/app/components/admin-app/admin-users/admin-users.component.scss
@@ -4,20 +4,5 @@
 :host {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 44px);
-}
-
-.component-container {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-}
-
-.add-margin {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  min-height: 0;
-  margin: 16px;
+  height: calc(100% - 44px);
 }

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
@@ -5,7 +5,9 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
 <div mat-dialog-container>
   <div mat-dialog-title>
-    @if (data.canEdit) {
+    @if (data.isNew) {
+    Create New Event Template
+    } @else if (data.canEdit) {
     Edit Event Template
     } @else {
     View Event Template
@@ -17,34 +19,47 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   @if (data.eventTemplate) {
   <mat-dialog-content mat-dialog-content>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
           <mat-label>Name (required)</mat-label>
           <input type="text" matInput [(ngModel)]="data.eventTemplate.name"
             [disabled]="!data.canEdit" />
         </mat-form-field>
+        <span class="copy-placeholder"></span>
       </div>
     </div>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
           <mat-label>Event Template Description</mat-label>
           <textarea matInput [(ngModel)]="data.eventTemplate.description"
             [disabled]="!data.canEdit"></textarea>
         </mat-form-field>
+        <span class="copy-placeholder"></span>
       </div>
     </div>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
-          <mat-label>Duration Hours</mat-label>
-          <input matInput type="number" [(ngModel)]="data.eventTemplate.durationHours"
+          <mat-label>Duration Hours (required)</mat-label>
+          <input matInput type="number" min="1" step="1"
+            [formControl]="durationHoursFormControl"
+            [errorStateMatcher]="notAnIntegerErrorState"
             [disabled]="!data.canEdit" />
+          @if (
+            durationHoursFormControl.hasError('required') ||
+            durationHoursFormControl.hasError('notAnInteger')
+            ) {
+            <mat-error>
+              Duration Hours must be an <strong>integer greater than 0</strong>
+            </mat-error>
+          }
         </mat-form-field>
+        <span class="copy-placeholder"></span>
       </div>
     </div>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
           <mat-label>Player View Template</mat-label>
           @if (data.canEdit) {
@@ -63,15 +78,17 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <input matInput type="text" [value]="viewSearchControl.value"
             [disabled]="true" />
           }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.viewId"
-            title="Copy:  {{ data.eventTemplate.viewId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
         </mat-form-field>
+        <span class="copy-button" matTooltip="Copy View ID">
+          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.viewId"
+            [disabled]="!data.eventTemplate.viewId">
+            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+          </button>
+        </span>
       </div>
     </div>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
           <mat-label>Caster Directory</mat-label>
           @if (data.canEdit) {
@@ -90,15 +107,17 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <input matInput type="text" [value]="directorySearchControl.value"
             [disabled]="true" />
           }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.directoryId"
-            title="Copy:  {{ data.eventTemplate.directoryId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
         </mat-form-field>
+        <span class="copy-button" matTooltip="Copy Directory ID">
+          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.directoryId"
+            [disabled]="!data.eventTemplate.directoryId">
+            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+          </button>
+        </span>
       </div>
     </div>
     <div class="add-margin">
-      <div>
+      <div class="field-with-copy">
         <mat-form-field class="full-width">
           <mat-label>Steamfitter Scenario Template</mat-label>
           @if (data.canEdit) {
@@ -123,11 +142,13 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <input matInput type="text" [value]="scenarioTemplateSearchControl.value"
             [disabled]="true" />
           }
-          <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
-            title="Copy:  {{ data.eventTemplate.scenarioTemplateId }}">
-            <mat-icon class="icon-color icon-20px" svgIcon="ic_clipboard_copy"></mat-icon>
-          </button>
         </mat-form-field>
+        <span class="copy-button" matTooltip="Copy Scenario Template ID">
+          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
+            [disabled]="!data.eventTemplate.scenarioTemplateId">
+            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+          </button>
+        </span>
       </div>
     </div>
     <div class="add-margin">
@@ -144,27 +165,23 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </mat-dialog-content>
   }
 
-  <div class="cssLayoutRowStartCenter bottom-button">
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template"
-        [disabled]="!data.canEdit">Save</button>
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
-    </div>
-    <div class="delete-button">
-      <button mat-stroked-button (click)="cloneEventTemplate()" class="clone-button" title="Clone this event template"
-        style="margin-left: 80px;" [disabled]="!data.canCreate">
-        Clone
-      </button>
-    </div>
-    <div class="delete-button"
-      [matTooltip]="data.hasEvents ? 'Cannot delete template with existing events' : 'Delete this event template'"
-      style="display: inline-block;">
+  <div class="bottom-button" mat-dialog-actions>
+    <button mat-stroked-button (click)="handleEditComplete(true)" title="Save this event template"
+      [disabled]="!data.canEdit">Save</button>
+    <button mat-stroked-button (click)="handleEditComplete(false)" title="Discard changes">Cancel</button>
+    @if (!data.isNew) {
+    <span class="spacer"></span>
+    <button mat-stroked-button (click)="cloneEventTemplate()" title="Clone this event template"
+      [disabled]="!data.canCreate">
+      Clone
+    </button>
+    <span
+      [matTooltip]="data.hasEvents ? 'Cannot delete template with existing events' : 'Delete this event template'">
       <button mat-stroked-button (click)="deleteEventTemplate()"
-        style="margin-left: 80px;" [disabled]="!data.canManage || data.hasEvents">
+        [disabled]="!data.canManage || data.hasEvents">
         Delete
       </button>
-    </div>
+    </span>
+    }
   </div>
 </div>

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.html
@@ -19,137 +19,121 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   @if (data.eventTemplate) {
   <mat-dialog-content mat-dialog-content>
     <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Name (required)</mat-label>
-          <input type="text" matInput [(ngModel)]="data.eventTemplate.name"
-            [disabled]="!data.canEdit" />
-        </mat-form-field>
-        <span class="copy-placeholder"></span>
-      </div>
+      <mat-form-field class="full-width">
+        <mat-label>Name (required)</mat-label>
+        <input type="text" matInput [(ngModel)]="data.eventTemplate.name"
+          [disabled]="!data.canEdit" />
+      </mat-form-field>
     </div>
     <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Event Template Description</mat-label>
-          <textarea matInput [(ngModel)]="data.eventTemplate.description"
-            [disabled]="!data.canEdit"></textarea>
-        </mat-form-field>
-        <span class="copy-placeholder"></span>
-      </div>
+      <mat-form-field class="full-width">
+        <mat-label>Event Template Description</mat-label>
+        <textarea matInput [(ngModel)]="data.eventTemplate.description"
+          [disabled]="!data.canEdit"></textarea>
+      </mat-form-field>
     </div>
     <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Duration Hours (required)</mat-label>
-          <input matInput type="number" min="1" step="1"
-            [formControl]="durationHoursFormControl"
-            [errorStateMatcher]="notAnIntegerErrorState"
-            [disabled]="!data.canEdit" />
-          @if (
-            durationHoursFormControl.hasError('required') ||
-            durationHoursFormControl.hasError('notAnInteger')
-            ) {
-            <mat-error>
-              Duration Hours must be an <strong>integer greater than 0</strong>
-            </mat-error>
+      <mat-form-field class="full-width">
+        <mat-label>Duration Hours (required)</mat-label>
+        <input matInput type="number" min="1" step="1"
+          [formControl]="durationHoursFormControl"
+          [errorStateMatcher]="matcher" />
+        @if (
+          durationHoursFormControl.hasError('required') ||
+          durationHoursFormControl.hasError('pattern')
+          ) {
+          <mat-error>
+            Duration Hours must be an <strong>integer greater than 0</strong>
+          </mat-error>
+        }
+      </mat-form-field>
+    </div>
+    <div class="add-margin">
+      <mat-form-field class="full-width">
+        <mat-label>Player View Template</mat-label>
+        @if (data.canEdit) {
+        <input matInput type="text" [formControl]="viewSearchControl" [matAutocomplete]="autoView" />
+        <mat-autocomplete #autoView="matAutocomplete" ngDefaultControl [displayWith]="selectedViewName"
+          [(ngModel)]="data.eventTemplate.viewId"
+          (optionSelected)="saveEventIds($event, 'viewId')" (opened)="filterViews()">
+          <mat-option [value]="null">None</mat-option>
+          @for (view of filteredViewList | async; track view) {
+          <mat-option [value]="view.id">
+            {{ view.name }}
+          </mat-option>
           }
-        </mat-form-field>
-        <span class="copy-placeholder"></span>
-      </div>
+        </mat-autocomplete>
+        } @else {
+        <input matInput type="text" [value]="viewSearchControl.value"
+          [disabled]="true" />
+        }
+        <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.viewId"
+          (click)="$event.stopPropagation()"
+          (cbOnSuccess)="onCopySuccess('View ID')"
+          [disabled]="!data.eventTemplate.viewId" matTooltip="Copy View ID">
+          <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+        </button>
+      </mat-form-field>
     </div>
     <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Player View Template</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="viewSearchControl" [matAutocomplete]="autoView" />
-          <mat-autocomplete #autoView="matAutocomplete" ngDefaultControl [displayWith]="selectedViewName"
-            [(ngModel)]="data.eventTemplate.viewId"
-            (optionSelected)="saveEventIds($event, 'viewId')" (opened)="filterViews()">
-            <mat-option [value]="null">None</mat-option>
-            @for (view of filteredViewList | async; track view) {
-            <mat-option [value]="view.id">
-              {{ view.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="viewSearchControl.value"
-            [disabled]="true" />
+      <mat-form-field class="full-width">
+        <mat-label>Caster Directory</mat-label>
+        @if (data.canEdit) {
+        <input matInput type="text" [formControl]="directorySearchControl" [matAutocomplete]="autoDirectory" />
+        <mat-autocomplete #autoDirectory="matAutocomplete" ngDefaultControl [displayWith]="selectedDirectoryName"
+          [(ngModel)]="data.eventTemplate.directoryId"
+          (optionSelected)="saveEventIds($event, 'directoryId')" (opened)="filterDirectories()">
+          <mat-option [value]="null">None</mat-option>
+          @for (directory of filteredDirectoryList | async; track directory) {
+          <mat-option [value]="directory.id">
+            {{ directory.name }}
+          </mat-option>
           }
-        </mat-form-field>
-        <span class="copy-button" matTooltip="Copy View ID">
-          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.viewId"
-            [disabled]="!data.eventTemplate.viewId">
-            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
-          </button>
-        </span>
-      </div>
+        </mat-autocomplete>
+        } @else {
+        <input matInput type="text" [value]="directorySearchControl.value"
+          [disabled]="true" />
+        }
+        <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.directoryId"
+          (click)="$event.stopPropagation()"
+          (cbOnSuccess)="onCopySuccess('Directory ID')"
+          [disabled]="!data.eventTemplate.directoryId" matTooltip="Copy Directory ID">
+          <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+        </button>
+      </mat-form-field>
     </div>
     <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Caster Directory</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="directorySearchControl" [matAutocomplete]="autoDirectory" />
-          <mat-autocomplete #autoDirectory="matAutocomplete" ngDefaultControl [displayWith]="selectedDirectoryName"
-            [(ngModel)]="data.eventTemplate.directoryId"
-            (optionSelected)="saveEventIds($event, 'directoryId')" (opened)="filterDirectories()">
-            <mat-option [value]="null">None</mat-option>
-            @for (directory of filteredDirectoryList | async; track directory) {
-            <mat-option [value]="directory.id">
-              {{ directory.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="directorySearchControl.value"
-            [disabled]="true" />
+      <mat-form-field class="full-width">
+        <mat-label>Steamfitter Scenario Template</mat-label>
+        @if (data.canEdit) {
+        <input matInput type="text" [formControl]="scenarioTemplateSearchControl"
+          [matAutocomplete]="autoScenarioTemplate" />
+        <mat-autocomplete #autoScenarioTemplate="matAutocomplete" ngDefaultControl
+          [displayWith]="selectedEventTemplateName"
+          [(ngModel)]="data.eventTemplate.scenarioTemplateId"
+          (optionSelected)="saveEventIds($event, 'scenarioTemplateId')" (opened)="filterScenarioTemplates()"
+          (closed)="scenarioTemplateSearchControl.setValue('')">
+          <mat-option [value]="null">None</mat-option>
+          @for (
+          scenarioTemplate of filteredScenarioTemplateList | async
+          ; track
+          scenarioTemplate) {
+          <mat-option [value]="scenarioTemplate.id">
+            {{ scenarioTemplate.name }}
+          </mat-option>
           }
-        </mat-form-field>
-        <span class="copy-button" matTooltip="Copy Directory ID">
-          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.directoryId"
-            [disabled]="!data.eventTemplate.directoryId">
-            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
-          </button>
-        </span>
-      </div>
-    </div>
-    <div class="add-margin">
-      <div class="field-with-copy">
-        <mat-form-field class="full-width">
-          <mat-label>Steamfitter Scenario Template</mat-label>
-          @if (data.canEdit) {
-          <input matInput type="text" [formControl]="scenarioTemplateSearchControl"
-            [matAutocomplete]="autoScenarioTemplate" />
-          <mat-autocomplete #autoScenarioTemplate="matAutocomplete" ngDefaultControl
-            [displayWith]="selectedEventTemplateName"
-            [(ngModel)]="data.eventTemplate.scenarioTemplateId"
-            (optionSelected)="saveEventIds($event, 'scenarioTemplateId')" (opened)="filterScenarioTemplates()"
-            (closed)="scenarioTemplateSearchControl.setValue('')">
-            <mat-option [value]="null">None</mat-option>
-            @for (
-            scenarioTemplate of filteredScenarioTemplateList | async
-            ; track
-            scenarioTemplate) {
-            <mat-option [value]="scenarioTemplate.id">
-              {{ scenarioTemplate.name }}
-            </mat-option>
-            }
-          </mat-autocomplete>
-          } @else {
-          <input matInput type="text" [value]="scenarioTemplateSearchControl.value"
-            [disabled]="true" />
-          }
-        </mat-form-field>
-        <span class="copy-button" matTooltip="Copy Scenario Template ID">
-          <button mat-icon-button ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
-            [disabled]="!data.eventTemplate.scenarioTemplateId">
-            <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
-          </button>
-        </span>
-      </div>
+        </mat-autocomplete>
+        } @else {
+        <input matInput type="text" [value]="scenarioTemplateSearchControl.value"
+          [disabled]="true" />
+        }
+        <button mat-icon-button matSuffix ngxClipboard [cbContent]="data.eventTemplate.scenarioTemplateId"
+          (click)="$event.stopPropagation()"
+          (cbOnSuccess)="onCopySuccess('Scenario Template ID')"
+          [disabled]="!data.eventTemplate.scenarioTemplateId" matTooltip="Copy Scenario Template ID">
+          <mat-icon class="mdi-20px" fontIcon="mdi-content-copy"></mat-icon>
+        </button>
+      </mat-form-field>
     </div>
     <div class="add-margin">
       <mat-checkbox [(ngModel)]="data.eventTemplate.isPublished"

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
@@ -6,32 +6,6 @@
   margin-bottom: 8px;
 }
 
-// Give the fields breathing room on the right so the copy button
-// sits clear of the dialog edge.
-::ng-deep .mat-mdc-dialog-content {
-  padding-right: 24px;
-}
-
-.field-with-copy {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-
-  .mat-mdc-form-field {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
-
-  .copy-button,
-  .copy-placeholder {
-    flex: 0 0 auto;
-    width: 48px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
 .bottom-button {
   display: flex;
   align-items: center;

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.scss
@@ -6,24 +6,48 @@
   margin-bottom: 8px;
 }
 
-.bottom-button {
-  margin-bottom: 10px;
-  margin-top: 10px;
+// Give the fields breathing room on the right so the copy button
+// sits clear of the dialog edge.
+::ng-deep .mat-mdc-dialog-content {
+  padding-right: 24px;
 }
 
-.delete-button {
+.field-with-copy {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .mat-mdc-form-field {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .copy-button,
+  .copy-placeholder {
+    flex: 0 0 auto;
+    width: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.bottom-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
   margin-top: 10px;
-  margin-right: 50px;
+
+  .spacer {
+    flex: 1 1 auto;
+  }
 }
 
 ::ng-deep .mat-autocomplete-panel {
   border-style: solid;
   border-color: var(--mat-sys-outline);
   border-width: 1px;
-}
-
-.clone-button {
-  margin-left: 40px;
 }
 
 .close-button {

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
@@ -41,6 +41,25 @@ export class UserErrorStateMatcher implements ErrorStateMatcher {
   }
 }
 
+/** Error when the duration is not an integer greater than 0. */
+export class NotIntegerErrorStateMatcher implements ErrorStateMatcher {
+  isErrorState(
+    control: UntypedFormControl | null,
+    form: FormGroupDirective | NgForm | null
+  ): boolean {
+    const hours = parseInt(control.value, 10);
+    let isNotAnInteger = Number.isNaN(hours) || hours <= 0;
+    if (!isNotAnInteger && !!control.value) {
+      isNotAnInteger = hours.toString() !== control.value.toString();
+    }
+    if (isNotAnInteger) {
+      control.setErrors({ notAnInteger: true });
+    }
+    const isSubmitted = form && form.submitted;
+    return !!(control && control.invalid && (control.dirty || isSubmitted));
+  }
+}
+
 @Component({
     selector: 'app-event-template-edit',
     templateUrl: './event-template-edit.component.html',
@@ -70,7 +89,6 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   ]);
   public durationHoursFormControl = new UntypedFormControl('', [
     Validators.required,
-    Validators.pattern('^[0-9]*$'),
   ]);
   public viewIdFormControl = new UntypedFormControl('', []);
   public directoryIdFormControl = new UntypedFormControl('', []);
@@ -78,6 +96,7 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   public isPublishedFormControl = new UntypedFormControl('', []);
   public useDynamicHostFormControl = new UntypedFormControl('', []);
   public matcher = new UserErrorStateMatcher();
+  public notAnIntegerErrorState = new NotIntegerErrorStateMatcher();
   public viewSearchControl = new UntypedFormControl('', []);
   public directorySearchControl = new UntypedFormControl('', []);
   public scenarioTemplateSearchControl = new UntypedFormControl('', []);
@@ -340,6 +359,14 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
     if (!saveChanges) {
       this.editComplete.emit({ action: '', eventTemplate: null });
     } else {
+      if (
+        this.durationHoursFormControl.invalid ||
+        this.durationHoursFormControl.hasError('notAnInteger')
+      ) {
+        return;
+      }
+      this.data.eventTemplate.durationHours =
+        parseInt(this.durationHoursFormControl.value, 10);
       this.editComplete.emit({
         action: 'save',
         eventTemplate: this.data.eventTemplate,

--- a/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-edit/event-template-edit.component.ts
@@ -28,6 +28,7 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA,
 } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 
 /** Error when invalid control is dirty, touched, or submitted. */
@@ -36,25 +37,6 @@ export class UserErrorStateMatcher implements ErrorStateMatcher {
     control: UntypedFormControl | null,
     form: FormGroupDirective | NgForm | null
   ): boolean {
-    const isSubmitted = form && form.submitted;
-    return !!(control && control.invalid && (control.dirty || isSubmitted));
-  }
-}
-
-/** Error when the duration is not an integer greater than 0. */
-export class NotIntegerErrorStateMatcher implements ErrorStateMatcher {
-  isErrorState(
-    control: UntypedFormControl | null,
-    form: FormGroupDirective | NgForm | null
-  ): boolean {
-    const hours = parseInt(control.value, 10);
-    let isNotAnInteger = Number.isNaN(hours) || hours <= 0;
-    if (!isNotAnInteger && !!control.value) {
-      isNotAnInteger = hours.toString() !== control.value.toString();
-    }
-    if (isNotAnInteger) {
-      control.setErrors({ notAnInteger: true });
-    }
     const isSubmitted = form && form.submitted;
     return !!(control && control.invalid && (control.dirty || isSubmitted));
   }
@@ -89,6 +71,7 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   ]);
   public durationHoursFormControl = new UntypedFormControl('', [
     Validators.required,
+    Validators.pattern('^[1-9][0-9]*$'),
   ]);
   public viewIdFormControl = new UntypedFormControl('', []);
   public directoryIdFormControl = new UntypedFormControl('', []);
@@ -96,7 +79,6 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   public isPublishedFormControl = new UntypedFormControl('', []);
   public useDynamicHostFormControl = new UntypedFormControl('', []);
   public matcher = new UserErrorStateMatcher();
-  public notAnIntegerErrorState = new NotIntegerErrorStateMatcher();
   public viewSearchControl = new UntypedFormControl('', []);
   public directorySearchControl = new UntypedFormControl('', []);
   public scenarioTemplateSearchControl = new UntypedFormControl('', []);
@@ -105,9 +87,19 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   constructor(
     public dialogService: DialogService,
     dialogRef: MatDialogRef<EventTemplateEditComponent>,
+    private snackBar: MatSnackBar,
     @Inject(MAT_DIALOG_DATA) public data: any
   ) {
     dialogRef.disableClose = true;
+  }
+
+  /**
+   * Notifies the user after a value is copied to the clipboard
+   */
+  onCopySuccess(label: string): void {
+    this.snackBar.open(`${label} copied to clipboard`, 'Dismiss', {
+      duration: 2000,
+    });
   }
 
   /**
@@ -155,6 +147,11 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
     this.durationHoursFormControl.setValue(
       this.data.eventTemplate.durationHours
     );
+    // Disable in code (not via template) to avoid the reactive-form
+    // "changed after checked" warning when combining [formControl] + [disabled].
+    if (!this.data.canEdit) {
+      this.durationHoursFormControl.disable();
+    }
     this.viewIdFormControl.setValue(this.data.eventTemplate.viewId);
     this.directoryIdFormControl.setValue(this.data.eventTemplate.directoryId);
     this.scenarioTemplateIdFormControl.setValue(
@@ -233,46 +230,43 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
   }
 
   filterViews() {
+    const term = (this._viewFilter ?? '').toLowerCase();
     const filteredList = this._viewList
       .sort((a: View, b: View) =>
-        a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
+        (a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1
       )
       .filter(
         (item) =>
-          item.name.toLowerCase().includes(this._viewFilter.toLowerCase()) ||
-          item.id.toLowerCase().includes(this._viewFilter.toLowerCase())
+          (item.name ?? '').toLowerCase().includes(term) ||
+          (item.id ?? '').toLowerCase().includes(term)
       );
     this.filteredViewList.next(filteredList);
   }
 
   filterDirectories() {
+    const term = (this._directoryFilter ?? '').toLowerCase();
     const filteredList = this._directoryList
       .sort((a: Directory, b: Directory) =>
-        a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
+        (a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1
       )
       .filter(
         (item) =>
-          item.name
-            .toLowerCase()
-            .includes(this._directoryFilter.toLowerCase()) ||
-          item.id.toLowerCase().includes(this._directoryFilter.toLowerCase())
+          (item.name ?? '').toLowerCase().includes(term) ||
+          (item.id ?? '').toLowerCase().includes(term)
       );
     this.filteredDirectoryList.next(filteredList);
   }
 
   filterScenarioTemplates() {
+    const term = (this._scenarioTemplateFilter ?? '').toLowerCase();
     const filteredList = this._scenarioTemplateList
-      .sort((a: View, b: View) =>
-        a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1
+      .sort((a: ScenarioTemplate, b: ScenarioTemplate) =>
+        (a.name ?? '').toLowerCase() < (b.name ?? '').toLowerCase() ? -1 : 1
       )
       .filter(
         (item) =>
-          item.name
-            .toLowerCase()
-            .includes(this._scenarioTemplateFilter.toLowerCase()) ||
-          item.id
-            .toLowerCase()
-            .includes(this._scenarioTemplateFilter.toLowerCase())
+          (item.name ?? '').toLowerCase().includes(term) ||
+          (item.id ?? '').toLowerCase().includes(term)
       );
     this.filteredScenarioTemplateList.next(filteredList);
   }
@@ -359,10 +353,7 @@ export class EventTemplateEditComponent implements OnInit, OnDestroy {
     if (!saveChanges) {
       this.editComplete.emit({ action: '', eventTemplate: null });
     } else {
-      if (
-        this.durationHoursFormControl.invalid ||
-        this.durationHoursFormControl.hasError('notAnInteger')
-      ) {
+      if (this.durationHoursFormControl.invalid) {
         return;
       }
       this.data.eventTemplate.durationHours =

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.html
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.html
@@ -69,7 +69,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 
     <ng-container matColumnDef="dateCreated">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Created</th>
-      <td mat-cell *matCellDef="let element">{{ element.dateCreated | date: 'yyyy-MM-dd' }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.dateCreated | date: 'yyyy-MM-dd HH:mm' }}</td>
     </ng-container>
 
     <ng-container matColumnDef="expandedDetail">

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.scss
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.scss
@@ -1,12 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-@use "@angular/material" as mat;
-
-:host {
-  @include mat.form-field-density(-5);
-}
-
 .search-field {
   min-width: 100px;
   margin-left: 10px;

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
@@ -38,7 +38,6 @@ import {
 } from 'src/app/generated/alloy.api';
 import { EventTemplateDataService } from 'src/app/data/event-template/event-template-data.service';
 import { EventTemplateEditComponent } from '../event-template-edit/event-template-edit.component';
-import { NameDialogComponent } from 'src/app/shared/name-dialog/name-dialog.component';
 import { ComnSettingsService } from '@cmusei/crucible-common';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { PermissionDataService } from 'src/app/data/permission/permission-data.service';
@@ -156,27 +155,33 @@ export class EventTemplateListComponent implements AfterViewInit, OnDestroy, OnI
   }
 
   addNewEventTemplate() {
-    const dialogRef = this.dialog.open(NameDialogComponent, {
-      width: '500px',
+    // Refresh template lists from external services before opening dialog
+    this.refreshTemplates.emit();
+
+    const dialogRef = this.dialog.open(EventTemplateEditComponent, {
+      minWidth: '400px',
+      maxWidth: '90vw',
+      width: '600px',
       data: {
-        title: 'Create New Event Template',
-        nameValue: '',
-        showDescription: true,
-        descriptionValue: '',
+        eventTemplate: <EventTemplate>{},
+        viewList: this.viewList,
+        directoryList: this.directoryList,
+        scenarioTemplateList: this.scenarioTemplateList,
+        canEdit: true,
+        canManage: true,
+        canCreate: this.permissionDataService.canCreateEventTemplates(),
+        hasEvents: false,
+        isNew: true,
       },
     });
-    dialogRef.componentInstance.title = 'Create New Event Template';
-    dialogRef.afterClosed().subscribe((result) => {
-      if (result && !result.wasCancelled) {
-        const eventTemplate = <EventTemplate>{
-          name: result.nameValue,
-          description: result.descriptionValue || '',
-        };
+    dialogRef.componentInstance.editComplete.subscribe((result) => {
+      if (result.action === 'save' || result.action === 'clone') {
         this.eventTemplateDataService
-          .addNew(eventTemplate)
+          .addNew(result.eventTemplate)
           .pipe(take(1))
           .subscribe();
       }
+      dialogRef.close();
     });
   }
 
@@ -192,7 +197,7 @@ export class EventTemplateListComponent implements AfterViewInit, OnDestroy, OnI
         const dialogRef = this.dialog.open(EventTemplateEditComponent, {
           minWidth: '400px',
           maxWidth: '90vw',
-          width: 'auto',
+          width: '600px',
           data: {
             eventTemplate: { ...eventTemplate },
             viewList: this.viewList,

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
@@ -38,6 +38,7 @@ import {
 } from 'src/app/generated/alloy.api';
 import { EventTemplateDataService } from 'src/app/data/event-template/event-template-data.service';
 import { EventTemplateEditComponent } from '../event-template-edit/event-template-edit.component';
+import { NameDialogComponent } from 'src/app/shared/name-dialog/name-dialog.component';
 import { ComnSettingsService } from '@cmusei/crucible-common';
 import { DialogService } from 'src/app/services/dialog/dialog.service';
 import { PermissionDataService } from 'src/app/data/permission/permission-data.service';
@@ -155,15 +156,28 @@ export class EventTemplateListComponent implements AfterViewInit, OnDestroy, OnI
   }
 
   addNewEventTemplate() {
-    const eventTemplate = <EventTemplate>{
-      name: 'New Event Template',
-      description: 'Add description',
-    };
-
-    this.eventTemplateDataService
-      .addNew(eventTemplate)
-      .pipe(take(1))
-      .subscribe();
+    const dialogRef = this.dialog.open(NameDialogComponent, {
+      width: '500px',
+      data: {
+        title: 'Create New Event Template',
+        nameValue: '',
+        showDescription: true,
+        descriptionValue: '',
+      },
+    });
+    dialogRef.componentInstance.title = 'Create New Event Template';
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result && !result.wasCancelled) {
+        const eventTemplate = <EventTemplate>{
+          name: result.nameValue,
+          description: result.descriptionValue || '',
+        };
+        this.eventTemplateDataService
+          .addNew(eventTemplate)
+          .pipe(take(1))
+          .subscribe();
+      }
+    });
   }
 
   editEventTemplate(eventTemplate: EventTemplate) {

--- a/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
+++ b/src/app/components/admin-app/event-templates/event-template-list/event-template-list.component.ts
@@ -167,8 +167,11 @@ export class EventTemplateListComponent implements AfterViewInit, OnDestroy, OnI
         viewList: this.viewList,
         directoryList: this.directoryList,
         scenarioTemplateList: this.scenarioTemplateList,
-        canEdit: true,
-        canManage: true,
+        // A new template has no id yet, so per-template edit/manage checks
+        // don't apply. The create permission gates opening this dialog and
+        // governs the template being created.
+        canEdit: this.permissionDataService.canCreateEventTemplates(),
+        canManage: this.permissionDataService.canCreateEventTemplates(),
         canCreate: this.permissionDataService.canCreateEventTemplates(),
         hasEvents: false,
         isNew: true,

--- a/src/app/components/admin-app/event-templates/event-templates.component.html
+++ b/src/app/components/admin-app/event-templates/event-templates.component.html
@@ -3,7 +3,7 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-<div class="component-container mat-elevation-z8">
+<div class="component-container">
   <app-event-template-list
     [viewList]="viewList"
     [directoryList]="directoryList"

--- a/src/app/components/admin-app/event-templates/event-templates.component.scss
+++ b/src/app/components/admin-app/event-templates/event-templates.component.scss
@@ -3,9 +3,6 @@
 
 .component-container {
   flex-direction: column;
-  min-width: 900px;
-  margin-top: 40px;
-  margin-left: 40px;
-  margin-right: 40px;
-  margin-bottom: 40px;
+  width: 100%;
+  height: 100%;
 }

--- a/src/app/components/admin-app/events/event-list/event-list.component.scss
+++ b/src/app/components/admin-app/events/event-list/event-list.component.scss
@@ -1,12 +1,6 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-@use "@angular/material" as mat;
-
-:host {
-  @include mat.form-field-density(-5);
-}
-
 .search-field {
   min-width: 100px;
   margin-left: 10px;

--- a/src/app/components/admin-app/events/events.component.html
+++ b/src/app/components/admin-app/events/events.component.html
@@ -3,6 +3,6 @@ Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 -->
 
-<div class="component-container mat-elevation-z8">
+<div class="component-container">
   <app-admin-event-list [refresh]="refresh"></app-admin-event-list>
 </div>

--- a/src/app/components/admin-app/events/events.component.scss
+++ b/src/app/components/admin-app/events/events.component.scss
@@ -3,9 +3,6 @@
 
 .component-container {
   flex-direction: column;
-  min-width: 1000px;
-  margin-top: 40px;
-  margin-left: 40px;
-  margin-right: 40px;
-  margin-bottom: 40px;
+  width: 100%;
+  height: 100%;
 }

--- a/src/app/shared/name-dialog/name-dialog.component.html
+++ b/src/app/shared/name-dialog/name-dialog.component.html
@@ -26,6 +26,19 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
       </mat-error>
     }
   </mat-form-field>
+
+  @if (data.showDescription) {
+    <mat-form-field class="form-full-width">
+      <mat-label>Description</mat-label>
+      <textarea
+        formControlName="description"
+        matInput
+        placeholder="Description"
+        autocomplete="off"
+        rows="3"
+      ></textarea>
+    </mat-form-field>
+  }
 </form>
 
 <mat-dialog-actions fxLayout="row" fxLayoutAlign="space-around center">

--- a/src/app/shared/name-dialog/name-dialog.component.ts
+++ b/src/app/shared/name-dialog/name-dialog.component.ts
@@ -29,6 +29,13 @@ export class NameDialogComponent {
       name: [data.nameValue, [Validators.required]],
     });
 
+    if (data.showDescription) {
+      this.form.addControl(
+        'description',
+        this.formBuilder.control(data.descriptionValue ?? '')
+      );
+    }
+
     if (data.validators) {
       this.validators = data.validators;
       const validators = (data.validators as Array<NameValidatorModel>).map(
@@ -49,6 +56,9 @@ export class NameDialogComponent {
       ? (this.data.removeArtifacts = this.removeArtifacts)
       : (this.data.removeArtifacts = false);
     this.data.nameValue = this.form?.get('name').value;
+    if (this.data.showDescription) {
+      this.data.descriptionValue = this.form?.get('description')?.value;
+    }
     this.data.wasCancelled = false;
     this.dialogRef.close(this.data);
   }

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -137,6 +137,14 @@ mat-icon,
   --mat-icon-color: var(--mat-sys-primary);
 }
 
+// but let icons inside disabled buttons grey out as Material intends
+button:disabled mat-icon,
+button:disabled .mat-icon,
+.mat-mdc-button-disabled mat-icon,
+.mat-mdc-button-disabled .mat-icon {
+  --mat-icon-color: var(--mat-sys-outline);
+}
+
 // remove the border around paginator items per page selection
 mat-paginator {
   --mat-form-field-outlined-outline-color: transparent;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -36,7 +36,6 @@ html {
     )
   );
   @include mat.icon-button-overrides((icon-color: var(--mat-sys-primary),));
-  --mat-icon-button-icon-color: var(--mat-sys-error);
 }
 
 body {
@@ -129,20 +128,6 @@ a {
   &:focus {
     color: var(--mat-sys-outline);
   }
-}
-
-// default all icons to the primary theme color
-mat-icon,
-.mat-icon {
-  --mat-icon-color: var(--mat-sys-primary);
-}
-
-// but let icons inside disabled buttons grey out as Material intends
-button:disabled mat-icon,
-button:disabled .mat-icon,
-.mat-mdc-button-disabled mat-icon,
-.mat-mdc-button-disabled .mat-icon {
-  --mat-icon-color: var(--mat-sys-outline);
 }
 
 // remove the border around paginator items per page selection


### PR DESCRIPTION
  Standardizes the Alloy admin pages to match the other Crucible apps and reworks the event template create flow to reuse the existing edit dialog.

  ## Changes

  ### Admin page layouts
  - Event Templates, Events, and Users admin pages now fill the whole content area with no card/box/shadow, matching the other apps' admin pages (e.g. Gallery collections, Caster modules).
  - Removed the `form-field-density(-5)` override so the search fields render at the standard height.
  - Event Templates "Created" column now shows the time (`yyyy-MM-dd HH:mm`).

  ### Add Event Template dialog
  - Adding a new event template now opens the full `EventTemplateEditComponent` instead of a simple name/description dialog, matching the add/edit pattern used elsewhere. The title switches to "Create New Event Template" and the
    Clone/Delete actions are hidden in new mode.
  - Duration Hours is validated as an integer greater than 0 (consistent with the Steamfitter scenario template dialog); save is blocked when invalid.
  - The copy-ID buttons for the View / Caster Directory / Scenario Template fields moved to the right of each field with working tooltips, and now use the standard `mdi-content-copy` icon. All input fields render at equal width.