### PR TITLE
Bump crucible-common to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "^21.2.1",
         "@angular/platform-browser-dynamic": "^21.2.1",
         "@angular/router": "^21.2.1",
-        "@cmusei/crucible-common": "0.7.2",
+        "@cmusei/crucible-common": "0.7.3",
         "@datorama/akita": "8.0.0",
         "@datorama/akita-ng-router-store": "8.0.0",
         "@datorama/akita-ngdevtools": "^7.0.0",
@@ -2892,9 +2892,8 @@
       }
     },
     "node_modules/@cmusei/crucible-common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.2.tgz",
-      "integrity": "sha512-wIxhKoylCBOmh/92TrZWoZkIZyDoqATHQKXLvOafKWoyBbB4D6oM78BoFdqu5mzDnOi5qQe2R2Dt1/dDptEwvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.3.tgz",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser": "^21.2.1",
     "@angular/platform-browser-dynamic": "^21.2.1",
     "@angular/router": "^21.2.1",
-    "@cmusei/crucible-common": "0.7.2",
+    "@cmusei/crucible-common": "0.7.3",
     "@datorama/akita": "8.0.0",
     "@datorama/akita-ng-router-store": "8.0.0",
     "@datorama/akita-ngdevtools": "^7.0.0",

--- a/src/app/components/admin-app/admin-groups/admin-groups.component.ts
+++ b/src/app/components/admin-app/admin-groups/admin-groups.component.ts
@@ -102,7 +102,7 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
   createGroup() {
     this.nameDialog('Create New Group?', '', { nameValue: '' }).subscribe(
       (result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.groupDataService
             .create({ name: result[NAME_VALUE] })
             .subscribe();
@@ -115,7 +115,7 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
     this.nameDialog('Rename ' + group.name, '', {
       nameValue: group.name,
     }).subscribe((result) => {
-      if (!result.wasCancelled) {
+      if (result) {
         this.groupDataService
           .edit({ id: group.id, name: result[NAME_VALUE] })
           .subscribe();
@@ -149,8 +149,6 @@ export class AdminGroupsComponent implements OnInit, AfterViewInit {
     dialogRef.componentInstance.title = title;
     dialogRef.componentInstance.message = message;
 
-    return dialogRef
-      .afterClosed()
-      .pipe(map((result) => result ?? { wasCancelled: true }));
+    return dialogRef.afterClosed();
   }
 }

--- a/src/app/components/admin-app/admin-roles/admin-system-roles/admin-system-roles.component.ts
+++ b/src/app/components/admin-app/admin-roles/admin-system-roles/admin-system-roles.component.ts
@@ -111,7 +111,7 @@ export class AdminSystemRolesComponent implements OnInit {
     this.nameDialog('Create New Role?', '', { nameValue: '' })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           this.roleService.createRole({ name: result[NAME_VALUE] }).subscribe();
         }
       });
@@ -121,7 +121,7 @@ export class AdminSystemRolesComponent implements OnInit {
     this.nameDialog('Rename Role?', '', { nameValue: role.name })
       .pipe(take(1))
       .subscribe((result) => {
-        if (!result.wasCancelled) {
+        if (result) {
           role.name = result[NAME_VALUE];
           this.roleService.editRole(role).subscribe();
         }
@@ -154,8 +154,6 @@ export class AdminSystemRolesComponent implements OnInit {
     dialogRef.componentInstance.title = title;
     dialogRef.componentInstance.message = message;
 
-    return dialogRef
-      .afterClosed()
-      .pipe(map((result) => result ?? { wasCancelled: true }));
+    return dialogRef.afterClosed();
   }
 }

--- a/src/app/shared/name-dialog/name-dialog.component.html
+++ b/src/app/shared/name-dialog/name-dialog.component.html
@@ -9,7 +9,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   submitLabel="Save"
   [submitDisabled]="!form.valid || !form.dirty"
   [guardUnsavedWork]="true"
-  (cancel)="onCancel()"
   (submit)="onClick()"
 >
   <div crucibleDialogContent [formGroup]="form" class="name-form">

--- a/src/app/shared/name-dialog/name-dialog.component.ts
+++ b/src/app/shared/name-dialog/name-dialog.component.ts
@@ -60,15 +60,6 @@ export class NameDialogComponent {
     if (this.data.showDescription) {
       this.data.descriptionValue = this.form?.get('description')?.value;
     }
-    this.data.wasCancelled = false;
-    this.dialogRef.close(this.data);
-  }
-
-  onCancel(): void {
-    this.data.artifacts && this.data.artifacts.length > 0
-      ? (this.data.removeArtifacts = this.removeArtifacts)
-      : (this.data.removeArtifacts = false);
-    this.data.wasCancelled = true;
     this.dialogRef.close(this.data);
   }
 }


### PR DESCRIPTION
## Summary

Bumps `@cmusei/crucible-common` from `0.7.2` to `0.7.3`.

**What 0.7.3 provides:**
- **Cancel now closes `crucible-dialog` via the injected `MatDialogRef` instead of a bare `mat-dialog-close` attribute.** Previously the bare attribute made Angular close with `''` (empty string) rather than `undefined`, which slipped past `result ?? {...}` and `!result.wasCancelled` guards — a cancelled dialog could be treated as a real result.
- **Loading-state layout fix**: the primary button's label and `<mat-progress-spinner>` are now wrapped and laid out as one centered inline-flex row, fixing the spinner dropping to its own line beneath the label text while `loading` is set.

**Impact on alloy.ui:**
- `NameDialogComponent.onCancel()` is now redundant (it existed solely to close the dialog with an explicit `{ wasCancelled: true }` payload to compensate for the old `''`-on-cancel behavior) and has been removed, along with its `(cancel)` binding in the template.
- `AdminGroupsComponent` and `AdminSystemRolesComponent` now guard their `nameDialog(...)` subscriptions with a simple truthy check (`if (result)`) instead of `if (!result.wasCancelled)`, since cancellation now reliably emits `undefined`.
- No consumer-visible behavior change other than fixing the same class of "cancel treated as submit" bug this crucible-common release itself targets — cancelling create/rename dialogs for groups and system roles now correctly no-ops.
